### PR TITLE
assign cpu

### DIFF
--- a/src/safeexec.erl
+++ b/src/safeexec.erl
@@ -8,7 +8,8 @@
 %%--------------------------------------------------------------------------------
 -export([
          open_port/2,
-         get_safeexec_path/0
+         get_safeexec_path/0,
+         make_safeexec_options/1 %% only for unit test
         ]).
 
 %%--------------------------------------------------------------------------------
@@ -34,19 +35,24 @@
                     | binary
                     | eof
                     | {parallelism, Boolean :: boolean()}
-                    | hide.
+                    | hide
+%% safeexec固有オプション                      
+                    | {assign_cpu_id_set, [CpuId | CpuIdRange]}, %% only used for linux
+      CpuId         :: non_neg_integer(),
+      CpuIdRange    :: {FromCpuId, ToCpuId},
+      FromCpuId     :: CpuId,
+      ToCpuId       :: CpuId.      
+      
 open_port({spawn, Command}, PortSettings) when is_binary(Command) ->
     safeexec:open_port({spawn, binary_to_list(Command)}, PortSettings);
 open_port({spawn, Command}, PortSettings) ->
-    erlang:open_port({spawn, quote(get_safeexec_path()) ++ " " ++ Command}, PortSettings);
+    {PortSettings2, SafeExecOptions} = make_safeexec_options(PortSettings),
+    erlang:open_port({spawn, quote(get_safeexec_path()) ++ " " ++ string:join((SafeExecOptions ++ [Command]), " ")}, PortSettings2);
 open_port({spawn_executable, FileName}, PortSettings0) ->
-    PortSettings1 = update_setting(arg0, fun (Arg0) -> Arg0 end, get_safeexec_path(), PortSettings0),
-    PortSettings2 = update_setting(args, fun (Args) -> [FileName | Args] end, [FileName], PortSettings1),
-    _ = case lists:member(in, PortSettings2) of
-            true  -> error({unsupported_option, in});  % inオプションがついているとポートが閉じたこと(= コマンド側の標準入力が閉じたこと)が検出できないので非サポート
-            false -> ok
-        end,
-    erlang:open_port({spawn_executable, get_safeexec_path()}, PortSettings2).
+    {PortSettings1, SafeExecOptions} = make_safeexec_options(PortSettings0),
+    PortSettings2 = update_setting(arg0, fun (Arg0) -> Arg0 end, get_safeexec_path(), PortSettings1),
+    PortSettings3 = update_setting(args, fun (Args) -> SafeExecOptions ++ [FileName] ++ Args end, SafeExecOptions ++ [FileName], PortSettings2),
+    erlang:open_port({spawn_executable, get_safeexec_path()}, PortSettings3).
 
 -spec get_safeexec_path() -> string().
 get_safeexec_path() ->
@@ -75,3 +81,51 @@ update_setting(Key, UpdateFun, InitialValue, [Setting | Settings]) ->
     [Setting | update_setting(Key, UpdateFun, InitialValue, Settings)];
 update_setting(Key, _UpdateFun, InitialValue, []) ->
     [{Key, InitialValue}].
+
+%% @doc PortSettingsからsafeexec固有の値を取り出し, safeexec binaryへ渡すオプションリストを生成する.
+-spec make_safeexec_options(PortSettings::[{atom(), term()} | atom()]) -> {LeftPortSettings::[{atom(), term()} | atom()], SafeExecOptions::[string()]}.
+make_safeexec_options(PortSettings) ->
+    lists:foldl(fun(F, {Settings, Options}) ->
+                        {Settings2, NewOption} = F(Settings),
+                        {Settings2, NewOption ++ Options}
+                end,
+                {PortSettings, []},
+                %% option処理関数群
+                [
+                 fun process_assign_cpu_id_set/1
+                ]).
+
+-spec process_assign_cpu_id_set(Settings::[{atom(), term()} | atom()]) ->
+                                       {Settings::[{atom(), term()} | atom()], AssignCpuIdSetOptions::[string()]}.
+process_assign_cpu_id_set(Settings) ->
+    case lists:keytake(assign_cpu_id_set, 1, Settings) of
+        false -> {Settings, []};
+        {value, {_, Value}, Settings2} ->
+            case os:type() of
+                %% only used for linux
+                {_, linux} ->
+                    Mask = to_bitmask(Value),
+                    {Settings2, ["--cpu", "0x" ++ integer_to_list(Mask, 16)]}; %% bitmaskを16進記法で出力
+                _ ->
+                    erlang:error(assign_cpu_id_set_is_only_used_for_linux)
+            end
+    end.
+
+to_bitmask(AssignCpuIdSetSpecs) ->
+    lists:foldl(fun(Spec, Mask) ->
+                        case Spec of
+                            %% [from, to]番目のbitを立てる
+                            {From, To} ->
+                                set_bit(Mask, {From, To});
+                            %% N番目のbitを立てる
+                            N ->
+                                set_bit(Mask, N)
+                        end
+                end,
+                0,
+                AssignCpuIdSetSpecs).
+
+set_bit(Mask, {From, To}) ->
+    Mask bor (((1 bsl (To + 1)) - 1) - ((1 bsl From) - 1));
+set_bit(Mask, N) ->
+    Mask bor (1 bsl N).

--- a/test/safeexec_tests.erl
+++ b/test/safeexec_tests.erl
@@ -12,19 +12,40 @@
 open_port_test_() ->
     [
      {"unix kill(SIGKILL)",
-      {timeout, 60,
-       fun () ->
-               lists:foreach(fun (I) ->
-                                     Port = safeexec:open_port({spawn_executable, "/bin/sleep"}, [{args, ["100"]}, exit_status]),
-                                     OsPid = proplists:get_value(os_pid, erlang:port_info(Port)),
-                                     os:cmd("kill -9 " ++ integer_to_list(OsPid)),
-                                     receive
-                                         {Port, {exit_status, _}} -> ?assert(true)
-                                     after 500 ->
-                                             ?debugVal(I),
-                                             ?debugVal(erlang:port_info(Port)),
-                                             ?assert(false)
-                                     end
-                             end, lists:seq(1, 3000))
-       end}}
+      fun () ->
+              lists:foreach(fun (I) ->
+                                    Port = safeexec:open_port({spawn_executable, "/bin/sleep"}, [{args, ["100"]}, exit_status]),
+                                    OsPid = proplists:get_value(os_pid, erlang:port_info(Port)),
+                                    os:cmd("kill -9 " ++ integer_to_list(OsPid)),
+                                    receive
+                                        {Port, {exit_status, _}} -> ?assert(true)
+                                    after 500 ->
+                                            ?debugVal(I),
+                                            ?debugVal(erlang:port_info(Port)),
+                                            ?assert(false)
+                                    end
+                            end, lists:seq(1, 500))
+      end}
+    ].
+
+make_safeexec_options_test_() ->
+    [
+     {"assign_cpu_id_set_test",
+      fun () ->
+              Os = case os:type() of
+                       {_, linux} -> linux;
+                       _ -> other_os
+                   end,
+              
+              try safeexec:make_safeexec_options([{assign_cpu_id_set, [0, {1, 3}, {3, 4}, 6]}]) of
+                  {Options2, Result} ->
+                      ?assertMatch(Os, linux),
+                      ?assertMatch(Result, ["--cpu", "0x5F"]),
+                      ?assertMatch(Options2, [])
+              catch
+                  %% linux以外でassign_cpu_id_set optionは指定できない
+                  error:assign_cpu_id_set_is_only_used_for_linux ->
+                      ?assertMatch(Os, other_os)
+              end
+      end}
     ].


### PR DESCRIPTION
- sched_setaffinityを利用し、safeexecが立ち上げるプロセスが実行可能なCPU IDを制限することができるようになる
- 参考 : sched_setaffinity(2)
  - https://linuxjm.osdn.jp/html/LDP_man-pages/man2/sched_setaffinity.2.html